### PR TITLE
Use HTTPS links for GeoIP database

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ Files can be downloaded here : <a href="http://dev.maxmind.com/geoip/legacy/geol
 
 <pre><code>mkdir -p /usr/local/share/GeoIP
 cd /usr/local/share/GeoIP
-wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
+wget https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
 gunzip *gz
 </code></pre>
 
@@ -151,8 +151,8 @@ gunzip *gz
 
 <pre><code>mkdir -p /usr/local/share/GeoIP
 cd /usr/local/share/GeoIP
-wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
-wget http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
+wget https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
+wget https://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
 gunzip *gz
 </code></pre>
 
@@ -179,7 +179,7 @@ gunzip *gz
 <p>Logswan is developed by Frederic Cambus</p>
 
 <ul>
-<li>Site : <a href="http://www.cambus.net">http://www.cambus.net</a>
+<li>Site : <a href="http://www.cambmus.net">http://www.cambus.net</a>
 </li>
 <li>Twitter: <a href="http://twitter.com/fcambus">http://twitter.com/fcambus</a>
 </li>


### PR DESCRIPTION
I've did some tests using SSLlabs:

![](http://up.frd.mn/2NlKO.png)

Both IPv4 and IPv6 are [rated Grade A](https://www.ssllabs.com/ssltest/analyze.html?d=geolite.maxmind.com&latest=yes). 
