### PR TITLE
NetBSD: Sanitize CMake script to build under NetBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,38 @@
 
 cmake_minimum_required (VERSION 2.6)
 
+include(GNUInstallDirs)
+include(FindPkgConfig)
+
 project (logswan C)
 
 include(CheckFunctionExists)
-include_directories(/usr/local/include /usr/pkg/include)
+include_directories(SYSTEM)
 
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_OPENBSD_SOURCE)
 check_function_exists(strtonum HAVE_STRTONUM)
 
-find_library(LIB_GEOIP NAMES GeoIP REQUIRED)
-find_library(LIB_JANSSON NAMES jansson REQUIRED)
+# LibM
+find_path(LIBM_INCLUDE_DIR math.h)
+find_library(LIBM_LIBRARIES NAMES m)
+include_directories(${LIBM_INCLUDE_DIR})
+message(STATUS "LIBM_INCLUDE_DIR ${LIBM_INCLUDE_DIR}")
+message(STATUS "LIBM_LIBRARIES ${LIBM_LIBRARIES}")
+
+# GeoIP (missing pkg-config)
+find_path(GEOIP_INCLUDE_DIR GeoIP.h)
+find_library(GEOIP_LIBRARIES NAMES GeoIP REQUIRED)
+include_directories(${GEOIP_INCLUDE_DIR})
+message(STATUS "GEOIP_INCLUDE_DIR ${GEOIP_INCLUDE_DIR}")
+message(STATUS "GEOIP_LIBRARIES ${GEOIP_LIBRARIES}")
+
+# jansson
+pkg_search_module(JANSSON REQUIRED jansson)
+include_directories(${JANSSON_INCLUDE_DIRS})
+link_directories(${JANSSON_LIBRARY_DIRS})
+message(STATUS "JANSSON_INCLUDE_DIRS ${JANSSON_INCLUDE_DIRS}")
+message(STATUS "JANSSON_LIBRARIES ${JANSSON_LIBRARIES}")
+message(STATUS "JANSSON_LIBRARY_DIRS ${JANSSON_LIBRARY_DIRS}")
 
 set (DEPS deps/hll/hll.c deps/MurmurHash3/MurmurHash3.c)
 set (SRC src/logswan.c src/config.c src/output.c src/parse.c)
@@ -31,14 +54,13 @@ if(NOT HAVE_STRTONUM)
   set (SRC ${SRC} compat/strtonum.c)
 endif()
 
-if(NOT DEFINED DATADIR)
-  set(DATADIR ${CMAKE_INSTALL_PREFIX}/share/GeoIP)
-endif()
+SET(GEOIPDATA ${CMAKE_INSTALL_PREFIX}/share/GeoIP CACHE PATH "Path to GeoIP data files")
 
 add_definitions(-Wall -Wextra -Werror -std=c99 -pedantic)
-add_definitions(-DDATADIR="${DATADIR}")
+add_definitions(-DDATADIR="${GEOIPDATA}")
 add_executable(logswan ${SRC} ${DEPS})
 
-target_link_libraries(logswan ${LIB_GEOIP} ${LIB_JANSSON} m)
+target_link_libraries(logswan ${GEOIP_LIBRARIES} ${JANSSON_LIBRARIES} ${LIBM_LIBRARIES})
 
 install(TARGETS logswan DESTINATION bin)
+install(FILES logswan.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)


### PR DESCRIPTION
```
compaq$ cmake ..
-- Found PkgConfig: /usr/pkg/bin/pkg-config (found version "0.29") 
-- The C compiler identification is GNU 4.8.5
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for strtonum
-- Looking for strtonum - found
-- LIBM_INCLUDE_DIR /usr/include
-- LIBM_LIBRARIES /lib/libm.so
-- GEOIP_INCLUDE_DIR /usr/pkg/include
-- GEOIP_LIBRARIES /usr/pkg/lib/libGeoIP.so
-- Checking for one of the modules 'jansson'
-- JANSSON_INCLUDE_DIRS /usr/pkg/include
-- JANSSON_LIBRARIES jansson
-- JANSSON_LIBRARY_DIRS /usr/pkg/lib
-- Configuring done
-- Generating done
-- Build files have been written to: /public/logswan/build
compaq$ make
Scanning dependencies of target logswan
[ 14%] Building C object CMakeFiles/logswan.dir/src/logswan.c.o
[ 28%] Building C object CMakeFiles/logswan.dir/src/config.c.o
[ 42%] Building C object CMakeFiles/logswan.dir/src/output.c.o
[ 57%] Building C object CMakeFiles/logswan.dir/src/parse.c.o
[ 71%] Building C object CMakeFiles/logswan.dir/deps/hll/hll.c.o
[ 85%] Building C object CMakeFiles/logswan.dir/deps/MurmurHash3/MurmurHash3.c.o
[100%] Linking C executable logswan
[100%] Built target logswan
compaq$ sudo make install
[100%] Built target logswan
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/bin/logswan
-- Removed runtime path from "/usr/local/bin/logswan"
-- Up-to-date: /usr/local/share/man/man1/logswan.1
```
