### PR TITLE
Fix title rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@
                          |                       :
                                                  .
 ```
-# Logswan [![Build Status][1]][2] [![Coverity Scan Build Status][3]][4]
+# Logswan 
+
+[![Build Status][1]][2] [![Coverity Scan Build Status][3]][4]
 
 Logswan is a fast Web log analyzer using probabilistic data structures. It is
 targeted at very large log files, typically APIs logs. It has constant memory


### PR DESCRIPTION
Move status badges to another line from the title. The problem 
is that it does not render correctly on the homepage[1] 
although it looks fine in README generated by GitHub.

[1]: https://www.logswan.org